### PR TITLE
Remove false information from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ So, only YouTube because that's the one that I personally care about.  Pull requ
 If on GNOME or similar you should be able to take advantage of your new powers immediately.  Otherwise, you can use something like [playerctl](https://github.com/acrisci/playerctl), perhaps bind it to a key or `XF86AudioPlay` and the like if your keyboard has them.
 ## Similar Projects
 * [plasma-browser-integration](https://github.com/KDE/plasma-browser-integration)
-  KDE only.  It's more general as it works on `<audio>` and `<video>` elements, though it misses out on some of the more "advanced" capabilities, such as cover art support.
+  It's more general as it works on `<audio>` and `<video>` elements, though it misses out on some of the more "advanced" capabilities, such as cover art support.
 * [shwsh/web-mpris2](https://github.com/shwsh/web-mpris2)
   A port of this extension to Tampermonkey/Greasemonkey (and WebSockets).
 


### PR DESCRIPTION
Despite the name Plasma Browser Integration is neither KDE nor Plasma only. It can be used on any or no DE. As a PoC I successfully installed it on XFCE.