### PR TITLE
Next/Previous buttons like in player. Enables manual autoplay.

### DIFF
--- a/providers/youtube.js
+++ b/providers/youtube.js
@@ -139,8 +139,8 @@ function enterVideo() {
     // that, but let's respect it by lying to MPRIS!
     video.Volume = 1;
 
-    video.CanGoNext = ($(".ytp-next-button").attr("aria-disabled") == "false");
-    video.CanGoPrevious= ($(".ytp-prev-button").attr("aria-disabled") == "false");
+    video.CanGoNext = ($(".ytp-next-button").attr("aria-disabled") === "false");
+    video.CanGoPrevious= ($(".ytp-prev-button").attr("aria-disabled") === "false");
 
     video.Rate = videoElement.playbackRate;
 
@@ -214,19 +214,17 @@ const COMMANDS = {
 
     Next() {
         let nextBtn = $(".ytp-next-button");
-        if(nextBtn.attr("aria-disabled") == "false") {
+        if (nextBtn.attr("aria-disabled") === "false")
             nextBtn.get(0).click();
-        }
     },
     Previous() {
         let prevBtn = $(".ytp-prev-button");
-        if(prevBtn.attr("aria-disabled") == "false") {
-            if (videoElement.currentTime > 2) {
+        if (prevBtn.attr("aria-disabled") === "false") {
+            if (videoElement.currentTime > 2)
                 // if the video is past its 2nd second pressing prev will start
                 // it from the beginning again, so we need to press twice with
                 // a bit of a delay between
                 setTimeout(() => prevBtn.get(0).click(), 100);
-            }
             prevBtn.get(0).click();
         }
     },

--- a/providers/youtube.js
+++ b/providers/youtube.js
@@ -139,8 +139,8 @@ function enterVideo() {
     // that, but let's respect it by lying to MPRIS!
     video.Volume = 1;
 
-    video.CanGoNext = playlist.index < playlist.length - 1;
-    video.CanGoPrevious = playlist.index > 0;
+    video.CanGoNext = ($(".ytp-next-button").attr("aria-disabled") == "false");
+    video.CanGoPrevious= ($(".ytp-prev-button").attr("aria-disabled") == "false");
 
     video.Rate = videoElement.playbackRate;
 
@@ -213,17 +213,21 @@ const COMMANDS = {
     },
 
     Next() {
-        if (playlist.length && playlist.index < playlist.length - 1)
-            $(".ytp-next-button").get(0).click();
+        let nextBtn = $(".ytp-next-button");
+        if(nextBtn.attr("aria-disabled") == "false") {
+            nextBtn.get(0).click();
+        }
     },
     Previous() {
-        if (playlist.length && playlist.index > 0) {
-            if (videoElement.currentTime > 2)
+        let prevBtn = $(".ytp-prev-button");
+        if(prevBtn.attr("aria-disabled") == "false") {
+            if (videoElement.currentTime > 2) {
                 // if the video is past its 2nd second pressing prev will start
                 // it from the beginning again, so we need to press twice with
                 // a bit of a delay between
-                setTimeout(() => $(".ytp-prev-button").get(0).click(), 100);
-            $(".ytp-prev-button").get(0).click();
+                setTimeout(() => prevBtn.get(0).click(), 100);
+            }
+            prevBtn.get(0).click();
         }
     },
 


### PR DESCRIPTION
I think it makes more sense to have the previous/next-buttons if and only if they are active in the original player, independent of a playlist. This is particularly useful because outside of playlists you will usually have a next-button to manually skip to the recommended autoplay video.

Tested in Chrome 61.0.3163.100.