### PR TITLE
Standardize 'previous' method behaviour

### DIFF
--- a/providers/soundcloud.js
+++ b/providers/soundcloud.js
@@ -267,10 +267,6 @@ const COMMANDS = {
     },
     Previous() {
         const skipControl = document.querySelector(".skipControl__previous");
-        if (getPosition() > 5e6)
-            // if the song is past its 5th second pressing previous will start
-            // it from the beginning again, so we need to press twice
-            skipControl.click();
         skipControl.click();
     },
 

--- a/providers/youtube.js
+++ b/providers/youtube.js
@@ -220,11 +220,6 @@ const COMMANDS = {
     Previous() {
         let prevBtn = $(".ytp-prev-button");
         if (prevBtn.attr("aria-disabled") === "false") {
-            if (videoElement.currentTime > 2)
-                // if the video is past its 2nd second pressing prev will start
-                // it from the beginning again, so we need to press twice with
-                // a bit of a delay between
-                setTimeout(() => prevBtn.get(0).click(), 100);
             prevBtn.get(0).click();
         }
     },


### PR DESCRIPTION
In modern media players, de facto standard is that the 'previous' method
can change current track to the previous track _or_ start it from the
beginning.

What was the rationale behind the workaround to remove the latter functionality?

Alternatively, it could be configurable (in the extension settings page?).